### PR TITLE
Attachment endpoint

### DIFF
--- a/apps/notes/models.py
+++ b/apps/notes/models.py
@@ -54,7 +54,8 @@ class Attachment(models.Model):
     def __str__(self) -> str:
         return f"{self.note.title} {self.create_at}"  
     
-    def clean(self):  #I create a clean method to validate the size of the file
+    #Para validar el tamaño del archivo
+    def clean(self):  
         max_file_size = 5 * 1024 * 1024  # 5MB
         if self.file_path and self.file_path.size>max_file_size:
             raise ValidationError(('File size cannot exceed 5MB'))

--- a/apps/notes/models.py
+++ b/apps/notes/models.py
@@ -2,6 +2,7 @@
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.models import User
 from django.db import models
+from django.core.exceptions import ValidationError
 
 
 class Note(models.Model):
@@ -42,7 +43,7 @@ class UserNote(models.Model):
 
 class Attachment(models.Model):
     """ Model Attachment """
-    note = models.ForeignKey(Note, on_delete=models.CASCADE)
+    note = models.ForeignKey(Note, related_name='attachments', on_delete=models.CASCADE)
     file_path = models.FileField(_("File Path"), upload_to='attachments/', null=True)  #I associate the flie_path variable with the media folder
     create_at = models.DateTimeField(_("Create Date"), auto_now_add=True)
 
@@ -51,7 +52,13 @@ class Attachment(models.Model):
         verbose_name_plural = _("Attachments")
 
     def __str__(self) -> str:
-        return f"{self.note.title} {self.create_at}"  # type: ignore
+        return f"{self.note.title} {self.create_at}"  
+    
+    def clean(self):  #I create a clean method to validate the size of the file
+        max_file_size = 5 * 1024 * 1024  # 5MB
+        if self.file_path and self.file_path.size>max_file_size:
+            raise ValidationError(('File size cannot exceed 5MB'))
+        
 
 
 class ListItems(models.Model):

--- a/apps/notes/router.py
+++ b/apps/notes/router.py
@@ -2,11 +2,13 @@ from rest_framework import routers
 from .views import (
         NoteViewSet,
         NoteUserViewSet,
+        AttachmentViewSet
         )
 
 router = routers.DefaultRouter()
 
 router.register(r'note', NoteViewSet)
 router.register(r'user-note', NoteUserViewSet, basename='user-note')
+router.register(r'attachment', AttachmentViewSet, basename='attachment') 
 
 urlpatterns = router.urls

--- a/apps/notes/serializer.py
+++ b/apps/notes/serializer.py
@@ -58,15 +58,15 @@ Serializadores para User Nota
 
 class AttachmentSerializer(serializers.ModelSerializer):
     """ Serializer para el archivo adjunto de las Notas relacionada a un Usuario """
-
+   
     class Meta:
         model = Attachment
-        fields = ['note', 'file_path', 'create_at']
+        fields = ['id', 'note', 'file_path', 'create_at']
         
-    def create(self, validated_data):  #To validate the size of the file
+    def create(self, validated_data):  
         attachment = Attachment(**validated_data)
         try:
-            attachment.full_clean() 
+            attachment.full_clean()  # Validar el tamaño del archivo
             attachment.save()
         except ValidationError as e:
             raise serializers.ValidationError({"detail": e.messages})
@@ -80,13 +80,19 @@ class UserForNoteUserSerializer(serializers.ModelSerializer):
         fields = ['id', 'username']
 
 
+class AttachmentForNoteUserSerializer(serializers.ModelSerializer):
+    """ Serializador Attachment para User Note """
+    class Meta:
+        model = Attachment
+        fields = ['id', 'file_path', 'create_at']
+
+
 class NoteForNoteUserSerialzier(serializers.ModelSerializer):
     """ Serializor Note para User Note """
-    Attachment = AttachmentSerializer(many=True, read_only=True)
-
+    attachments = AttachmentForNoteUserSerializer(many=True, read_only=True)
     class Meta:
         model = Note
-        fields = ['id', 'title', 'content', 'attachment']
+        fields = ['id', 'title', 'content', 'attachments']
 
 
 class UserNoteListSerializer(serializers.ModelSerializer):

--- a/apps/notes/serializer.py
+++ b/apps/notes/serializer.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 from rest_framework.reverse import reverse
-from .models import Note, UserNote
+from .models import Note, UserNote, Attachment
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 
 
 """
@@ -55,6 +56,23 @@ Serializadores para User Nota
 """
 
 
+class AttachmentSerializer(serializers.ModelSerializer):
+    """ Serializer para el archivo adjunto de las Notas relacionada a un Usuario """
+
+    class Meta:
+        model = Attachment
+        fields = ['note', 'file_path', 'create_at']
+        
+    def create(self, validated_data):  #To validate the size of the file
+        attachment = Attachment(**validated_data)
+        try:
+            attachment.full_clean() 
+            attachment.save()
+        except ValidationError as e:
+            raise serializers.ValidationError({"detail": e.messages})
+        return attachment
+    
+
 class UserForNoteUserSerializer(serializers.ModelSerializer):
     """ Serializador User para User Note """
     class Meta:
@@ -64,9 +82,11 @@ class UserForNoteUserSerializer(serializers.ModelSerializer):
 
 class NoteForNoteUserSerialzier(serializers.ModelSerializer):
     """ Serializor Note para User Note """
+    Attachment = AttachmentSerializer(many=True, read_only=True)
+
     class Meta:
         model = Note
-        fields = ['id', 'title', 'content']
+        fields = ['id', 'title', 'content', 'attachment']
 
 
 class UserNoteListSerializer(serializers.ModelSerializer):
@@ -114,3 +134,5 @@ class UserNoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserNote
         fields = '__all__'
+
+


### PR DESCRIPTION
En el modelo validamos el tamaño del archivo; agregamos la ruta para 'Attachment'; creamos el serializador para 'Attachment' configurando el acceso a todos los archivos adjuntos desde cada nota; Creamos la vista de 'Attachment' donde se realiza el CRUD menos la modificación. 